### PR TITLE
Fix readme instructions for server-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can configure lein-postgres with a config map in your project.clj
   :postgres {:port 12345 ;optional, defaults to a random free port
              :clean-data-directory true ;optional, defaults to true - should we cleanup the data directory on close
              :data-directory "/tmp/embeddedpostgres" ;optional, sets the temporary data directory
-             :server-config {"max_connections" : 300}} ;optional, allows you to set additional server config options
+             :server-config {:max_connections "300"}} ;optional, allows you to set additional server config options
 ```
 
 See [here](https://github.com/opentable/otj-pg-embedded/blob/master/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgreSQL.java) for more information on additional server-config options.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-postgres "0.1.2-SNAPSHOT"
+(defproject lein-postgres "0.1.2"
   :description "Lein plugin wrapping the open table java embedded postgres component"
   :url "http://github.com/whostolebenfrog/lein-postgres"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-postgres "0.1.2"
+(defproject lein-postgres "0.1.2-SNAPSHOT"
   :description "Lein plugin wrapping the open table java embedded postgres component"
   :url "http://github.com/whostolebenfrog/lein-postgres"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
   :dependencies [[com.opentable.components/otj-pg-embedded "0.9.0"]]
-  :plugins [[s3-wagon-private "1.3.0"]]
-  :repositories [["compt" {:url "s3p://maven.compt.io/releases" :no-auth true}]])
+  :plugins [[s3-wagon-private "1.3.2"]]
+  :repositories [["compt" {:url "s3p://private-maven.compt.io/releases"
+                           :no-auth true
+                           :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[com.opentable.components/otj-pg-embedded "0.4.0"]])
+  :dependencies [[com.opentable.components/otj-pg-embedded "0.9.0"]]
+  :plugins [[s3-wagon-private "1.3.0"]]
+  :repositories [["compt" {:url "s3p://maven.compt.io/releases" :no-auth true}]])


### PR DESCRIPTION
The config provided in the readme causes lein-postgres to crash with the following stack trace:

```
java.lang.ClassCastException: Cannot cast java.lang.Long to java.lang.String
 at java.lang.Class.cast (Class.java:3361)
    clojure.lang.Reflector.boxArg (Reflector.java:427)
    clojure.lang.Reflector.boxArgs (Reflector.java:460)
    clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:58)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:28)
    leiningen.postgres$apply_server_config.invokeStatic (postgres.clj:15)
    leiningen.postgres$apply_server_config.invoke (postgres.clj:11)
    leiningen.postgres$start_db.invokeStatic (postgres.clj:37)
    leiningen.postgres$start_db.invoke (postgres.clj:18)
    leiningen.postgres$postgres.invokeStatic (postgres.clj:44)
    leiningen.postgres$postgres.doInvoke (postgres.clj:39)
    clojure.lang.RestFn.invoke (RestFn.java:423)
    ...
```
This can be traced down the call [`apply-server-config`](https://github.com/whostolebenfrog/lein-postgres/blob/master/src/leiningen/postgres.clj#L15), which looking at its [definition](https://github.com/opentable/otj-pg-embedded/blob/master/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java#L452) only takes strings as the value argument. This fixes the readme to provide a functioning config. cc @whostolebenfrog 