### PR TITLE
Up otj-pg-embedded to 0.9.0 which uses postgres 9.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[com.opentable.components/otj-pg-embedded "0.4.0"]])
+  :dependencies [[com.opentable.components/otj-pg-embedded "0.9.0"]])

--- a/src/leiningen/postgres.clj
+++ b/src/leiningen/postgres.clj
@@ -1,6 +1,6 @@
 (ns leiningen.postgres
   (:require [leiningen.core.main :as main])
-  (:import [com.opentable.db.postgres.embedded EmbeddedPostgreSQL]
+  (:import [com.opentable.db.postgres.embedded EmbeddedPostgres]
            [java.io File]))
 
 (defn- config-value
@@ -22,7 +22,7 @@
         data-directory (get (project :postgres) :data-directory)
         server-config (get (project :postgres) :server-config)
         port (get (project :postgres) :port)]
-    (.start (cond-> (EmbeddedPostgreSQL/builder)
+    (.start (cond-> (EmbeddedPostgres/builder)
 
                     port
                     (.setPort port)


### PR DESCRIPTION
Tested by installing locally, and running `$ lein postgres` in a shell, producing the following output:

```
$ lein postgres
lein-postgres: starting postgres instance
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
The files belonging to this database system will be owned by user "leo".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.UTF-8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /tmp/embeddedpostgres ... ok
creating subdirectories ... ok
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting dynamic shared memory implementation ... posix
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

Success. You can now start the database server using:

    /var/folders/tn/ds_sxvkj34s3t6hscrf7637h0000gn/T/embedded-pg/PG-bb0d2807196ef46c2b2e80868258adae/bin/pg_ctl -D /tmp/embeddedpostgres -l logfile start

server starting
LOG:  database system was shut down at 2017-07-20 09:33:13 EDT
LOG:  MultiXact member wraparound protections are now enabled
LOG:  database system is ready to accept connections
LOG:  autovacuum launcher started
lein-postgres: started on port: 12345
```
In a separate shell I connected to the created server to confirm that it worked:

```
psql -p 12345 -h localhost -U postgres --password
Password for user postgres:
psql (9.6.2, server 9.6.3)
Type "help" for help.

postgres=#
```

cc @whostolebenfrog 